### PR TITLE
Adding `gulpplugin` keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
   },
   "keywords": [
     "gulp",
+    "gulpplugin",
     "append",
     "insert",
     "prepend"
   ],
   "author": "Ryan Schmukler <ryan@slingingcode.com> (http://slingingcode.com/)",
   "license": "MIT",
+  "homepage": "https://github.com/rschmukler/gulp-insert/",
   "bugs": {
     "url": "https://github.com/rschmukler/gulp-insert/issues"
   },


### PR DESCRIPTION
Adding keyword so module gets added to http://gulpjs.com/plugins/ directory.
