### PR TITLE
chore: use HTTPS package metadata URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/rschmukler/gulp-insert"
+    "url": "git+https://github.com/rschmukler/gulp-insert.git"
   },
   "keywords": [
     "gulp",


### PR DESCRIPTION
## Summary
- update the package repository metadata from `git://` to `git+https://`

## Validation
- `node -e "const p=require('./package.json'); if (p.name !== 'gulp-insert') throw new Error('name mismatch'); if (p.repository?.url !== 'git+https://github.com/rschmukler/gulp-insert.git') throw new Error(JSON.stringify(p.repository)); console.log(JSON.stringify(p.repository))"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`
- `npm test`
